### PR TITLE
Revert back to using non-transcluent nav- and statusbar

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,8 +6,8 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:windowTranslucentNavigation">true</item>
-        <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:windowTranslucentStatus">false</item>
         <item name="android:windowActionBarOverlay">true</item>
     </style>
     <style name="AppTheme.Launcher">


### PR DESCRIPTION
The status-bar, along with map controls are way too low when translucency is on. 

This is a cherry-pick from beea1389b5dd95f02b94dd41281f7a0fcdc6f453
Somehow this got overwritten