### PR TITLE
Bump targetCompatibility to Java 8

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+    compileOptions {
+        sourceCompatibility = '1.8'
+        targetCompatibility = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Because of our minSdk is set to 24, there is no reason to compile for
Java 7, all features are supported by Android API level.
By setting it to version 8, lambda functions can for example be
used.

See https://developer.android.com/studio/write/java8-support