### PR TITLE
Collapse slider when map is clicked

### DIFF
--- a/app/src/main/java/com/example/ainterak/MapsActivity.java
+++ b/app/src/main/java/com/example/ainterak/MapsActivity.java
@@ -91,6 +91,9 @@ public class MapsActivity extends FragmentActivity implements
             onMyLocationButtonClick();
         });
 
+        // Collapse the menuSlider if a click on the map is registered
+        mMap.setOnMapClickListener(v -> menuSlider.collapseSlider());
+
         addBuskarToMap();
     }
 

--- a/app/src/main/java/com/example/ainterak/MenuSlider.java
+++ b/app/src/main/java/com/example/ainterak/MenuSlider.java
@@ -74,4 +74,11 @@ public class MenuSlider {
         mAdapter = new MyAdapter(dataset);
         recyclerView.setAdapter(mAdapter);
     }
+
+    /**
+     * Set the slider's panel state to collapsed.
+     */
+    public void collapseSlider() {
+        mLayout.setPanelState(SlidingUpPanelLayout.PanelState.COLLAPSED);
+    }
 }


### PR DESCRIPTION
If the slider is set to be expanded, and a click on the map is
registered, then the slider is collapsed.
Clicks on markers are NOT registered as map clicks, therefore marker
clicks with an expanded slider will NOT collapse it.