### PR TITLE
Fix collapsing slider when map is clicked

### DIFF
--- a/app/src/main/java/com/example/ainterak/MapsActivity.java
+++ b/app/src/main/java/com/example/ainterak/MapsActivity.java
@@ -103,7 +103,7 @@ public class MapsActivity extends FragmentActivity implements
         });
 
         // Collapse the menuSlider if a click on the map is registered
-        mMap.setOnMapClickListener(v -> menuSlider.collapseSlider());
+        infoWindowManager.setOnMapClickListener(v -> menuSlider.collapseSlider());
 
         addBuskarToMap();
     }


### PR DESCRIPTION
Due to adding InfoWindow, the onMapClicked callback never ran. This
fixes it.