### PR TITLE
Show centered markers above sliding panel

### DIFF
--- a/app/src/main/java/com/example/ainterak/MapsActivity.java
+++ b/app/src/main/java/com/example/ainterak/MapsActivity.java
@@ -177,9 +177,20 @@ public class MapsActivity extends FragmentActivity implements
             mLocationProvider.getLocation().addOnSuccessListener(this, (Location location) -> {
                 if (location == null) return;
                 latLngBuilder.include(new LatLng(location.getLatitude(), location.getLongitude()));
-                mMap.moveCamera(CameraUpdateFactory
-                        .newLatLngBounds(latLngBuilder.build(), width, height, padding)
-                );
+
+                // If panel is set to it's anchor point, show markers above it
+                if (menuSlider.mLayout.getPanelState() == SlidingUpPanelLayout.PanelState.ANCHORED) {
+                    int bottomPadding = (int) (menuSlider.mLayout.getAnchorPoint() * height);
+                    mMap.setPadding(0, 0, 0, bottomPadding);
+                    mMap.moveCamera(CameraUpdateFactory
+                            .newLatLngBounds(latLngBuilder.build(), width, height, padding)
+                    );
+                    mMap.setPadding(0, 0, 0, 0);
+                } else {
+                    mMap.moveCamera(CameraUpdateFactory
+                            .newLatLngBounds(latLngBuilder.build(), width, height, padding)
+                    );
+                }
             });
 
             // Limit zoom to 16. If it's higher then it is hard to find where on the map the user is.

--- a/app/src/main/java/com/example/ainterak/MenuSlider.java
+++ b/app/src/main/java/com/example/ainterak/MenuSlider.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class MenuSlider {
 
     private SupportActivity activity;
-    private SlidingUpPanelLayout mLayout;
+    SlidingUpPanelLayout mLayout;
     private RecyclerView recyclerView;
     private RecyclerView.Adapter mAdapter;
     private RecyclerView.LayoutManager layoutManager;


### PR DESCRIPTION
Before when the app loaded some of the markers could end up under the
sliding panel (because it loads as anchored). This commit forces the
markers to always be over the sliding panel.