### PR TITLE
Set panel state to start as anchored

### DIFF
--- a/app/src/main/res/layout/activity_maps.xml
+++ b/app/src/main/res/layout/activity_maps.xml
@@ -8,7 +8,9 @@
     android:gravity="bottom"
     sothree:umanoPanelHeight="68dp"
     sothree:umanoScrollableView="@id/menu_list"
-    sothree:umanoShadowHeight="2dp">
+    sothree:umanoShadowHeight="2dp"
+    sothree:umanoInitialState="anchored"
+    >
 
     <RelativeLayout
         android:id="@+id/mapContainer"


### PR DESCRIPTION
The panel's state is set to collapsed by default, and we change it
programmatically. It starting as collapsed causes the FAB in maps
activity to be partially hidden by the menu slider.